### PR TITLE
Add job wrappers and HTCondor ftransfers when running w/o shared FS

### DIFF
--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -132,7 +132,6 @@ class Executor(RemoteExecutor):
                 top_most_input_directories = {path.split(sep)[0] for path in job.input}
                 submit_dict["transfer_input_files"] = ", ".join(sorted(top_most_input_directories))
 
-
             if self.workflow.configfiles:
                 # Note that when we transfer the config file(s), we'll pass Condor an absolute path, but we need to
                 # modify the job args to use only the file name(s) when execution begins, because the configfile(s)

--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -12,8 +12,9 @@ from snakemake_interface_executor_plugins.jobs import (
 from snakemake_interface_common.exceptions import WorkflowError  # noqa
 
 import htcondor
-from os.path import join
-from os import makedirs
+from os.path import join, basename, abspath, dirname
+from os import makedirs, sep
+import re
 
 
 # Optional:
@@ -30,6 +31,16 @@ class ExecutorSettings(ExecutorSettingsBase):
             "help": "Directory where the job will create a directory to store log, "
             "output and error files.",
             "required": True,
+        },
+    )
+
+    jobwrapper: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "A job wrapper script that can be used for remote environment "
+            "setup and teardown. The script must pass any provided arguments to the "
+            "executable, e.g. `snakemake $@`.",
+            "required": False,
         },
     )
 
@@ -60,6 +71,8 @@ common_settings = CommonSettings(
     auto_deploy_default_storage_provider=True,
     # specify initial amount of seconds to sleep before checking for job status
     init_seconds_before_status_checks=0,
+    # indicate that the HTCondor executor can transfer its own files to the remote node
+    can_transfer_local_files=True,
 )
 
 
@@ -74,6 +87,7 @@ class Executor(RemoteExecutor):
 
         # jobDir: Directory where the job will tore log, output and error files.
         self.jobDir = self.workflow.executor_settings.jobdir
+        self.jobWrapper = self.workflow.executor_settings.jobwrapper
 
     def run_job(self, job: JobExecutorInterface):
         # Submitting job to HTCondor
@@ -81,8 +95,14 @@ class Executor(RemoteExecutor):
         # Creating directory to store log, output and error files
         makedirs(self.jobDir, exist_ok=True)
 
-        job_exec = self.get_python_executable()
-        job_args = self.format_job_exec(job).removeprefix(job_exec + " ")
+        if self.jobWrapper:
+            job_exec = basename(self.jobWrapper)
+            # The wrapper script will take as input all snakemake arguments, so we assume
+            # it contains something like `snakemake $@`
+            job_args = self.format_job_exec(job).removeprefix("python -m snakemake ")
+        else:
+            job_exec = self.get_python_executable()
+            job_args = self.format_job_exec(job).removeprefix(job_exec + " ")
 
         # HTCondor cannot handle single quotes
         if "'" in job_args:
@@ -102,11 +122,46 @@ class Executor(RemoteExecutor):
             "request_cpus": str(job.threads),
         }
 
+        # If we're not using a shared filesystem, we need to setup transfers
+        # for any job wrapper, config files, input files, etc
+        if not self.workflow.storage_settings.shared_fs_usage:
+            if job.input:
+                # When snakemake passes its input args to the executable, it does so using the path relative
+                # to the specified input directory, e.g. `input/foo/bar`, so we need to transfer the top-most
+                # input directories the will contain any subdirectories/files needed by the job.
+                top_most_input_directories = {path.split(sep)[0] for path in job.input}
+                submit_dict["transfer_input_files"] = ", ".join(sorted(top_most_input_directories))
+
+
+            if self.workflow.configfiles:
+                # Note that when we transfer the config file(s), we'll pass Condor an absolute path, but we need to
+                # modify the job args to use only the file name(s) when execution begins, because the configfile(s)
+                # will be accessed from the job's scratch dir.
+                config_fnames = []
+                for fpath in self.workflow.configfiles:
+                    fname = basename(fpath)
+                    config_fnames.append(fname)
+                config_arg = " ".join(config_fnames)
+
+                configfiles_pattern = r"--configfiles .*?(?=( --|$))"
+                submit_dict["arguments"] = re.sub(configfiles_pattern, f"--configfiles {config_arg}", submit_dict["arguments"])
+
+                if submit_dict["transfer_input_files"]:
+                    submit_dict["transfer_input_files"] += ", " + ", ".join(str(path) for path in self.workflow.configfiles)
+                else:
+                    submit_dict["transfer_input_files"] = ", ".join(str(path) for path in self.workflow.configfiles)
+
+            if job.output:
+                # For outputs, we only care about the parent directory, which we'll tell
+                # HTCondor to transfer back to the AP.
+                top_most_output_directories = {path.split(sep)[0] for path in job.output}
+                submit_dict["transfer_output_files"] = ", ".join(sorted(top_most_output_directories))
+
         # Basic commands
         if job.resources.get("getenv"):
             submit_dict["getenv"] = job.resources.get("getenv")
         else:
-            submit_dict["getenv"] = True
+            submit_dict["getenv"] = False
 
         for key in ["environment", "input", "max_materialize", "max_idle"]:
             if job.resources.get(key):


### PR DESCRIPTION
This commit adds a new CLI to specify a job wrapper (i.e. an HTCondor executable). When provided, the script should pass all of the executor's generated args to the snakemake executable, i.e. it should contain something like:
```
python -m snakemake $@
```

This commit also takes a first pass at allowing HTCondor to manage its own file transfers, and makes use of the `can_transfer_local_files` executor interface introduced in PRs snakemake-interface-executor-plugins:67 and snakemake:2921.